### PR TITLE
Fix single buy confirm parameters count validation

### DIFF
--- a/Bancard/Operations/SingleBuy/Confirm.php
+++ b/Bancard/Operations/SingleBuy/Confirm.php
@@ -26,7 +26,7 @@ class Confirm extends \Bancard\Bancard\Core\Request
 
     private function validateData(array $data)
     {
-        if (count($data) <= 1) {
+        if (count($data) < 1) {
             throw new \InvalidArgumentException("Invalid argument count.");
         }
 


### PR DESCRIPTION
El método validateData validaba la cantidad de parámetros menor o igual a uno. Single buy confirm recibe un solo parámetro (shop_process_id), entonces la validación siempre arrojaba la excepción.